### PR TITLE
More accurate greping

### DIFF
--- a/opt/retropie/configs/all/runcommand-onstart.sh
+++ b/opt/retropie/configs/all/runcommand-onstart.sh
@@ -58,7 +58,7 @@ if [[ "$system" == "arcade" ]] || [[ "$system" == "fba" ]] || [[ "$system" == "m
     echo "rom $rom_bn" >> $log
     
 	# get resolution of rom
-	rom_resolution=$(grep "$rom_bn;" $path/arcade_res_table.txt | cut -d";" -f3) 
+	rom_resolution=$(grep "^$rom_bn;" $path/arcade_res_table.txt | cut -d";" -f3) 
 	rom_resolution_width=$(echo $rom_resolution | cut -f1 -d"x")
 	rom_resolution_height=$(echo $rom_resolution | cut -f2 -d"x" | cut -f1 -d"@")
 	rom_resolution_freq=$(echo $rom_resolution | cut -f2 -d"x" | cut -f2 -d"@")


### PR DESCRIPTION
Example :

```bash
> grep "mk;" /opt/retropie/configs/all/arcade_res_table.txt

galagamk;"Galaga (Midway set 2)";288x224@60;V
grdnstrmk;"Jeon Sin - Guardian Storm (Korea)";256x224@57;V
gulfstrmk;"Gulf Storm (Korea)";384x240@60;V
mk;"Mortal Kombat";1920x254@53.2;H

> grep "^mk;" /opt/retropie/configs/all/arcade_res_table.txt
mk;"Mortal Kombat";1920x254@53.2;H
```